### PR TITLE
Building issue fix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,7 +57,7 @@ REPMGRD_OBJS = repmgrd.o repmgrd-physical.o repmgrd-bdr.o configfile.o configfil
 DATE=$(shell date "+%Y-%m-%d")
 
 repmgr_version.h: repmgr_version.h.in
-	sed '0,/REPMGR_VERSION_DATE/s,\(REPMGR_VERSION_DATE\).*,\1 "$(DATE)",' $< >$@
+	$(SED) -E 's/REPMGR_VERSION_DATE.*""/REPMGR_VERSION_DATE "$(DATE)"/' $< >$@; \
 	sed -i -E 's/PG_ACTUAL_VERSION_NUM/PG_ACTUAL_VERSION_NUM $(VERSION_NUM)/' $@
 
 configfile-scan.c: configfile-scan.l

--- a/controldata.c
+++ b/controldata.c
@@ -312,6 +312,7 @@ get_controlfile(const char *DataDir)
 
     if (version_num >= 120000)
     {
+#if PG_ACTUAL_VERSION_NUM >= 120000
         ControlFileData12 *ptr = (struct ControlFileData12 *)ControlFileDataPtr;
         control_file_info->system_identifier = ptr->system_identifier;
         control_file_info->state = ptr->state;
@@ -320,6 +321,10 @@ get_controlfile(const char *DataDir)
         control_file_info->timeline = ptr->checkPointCopy.ThisTimeLineID;
         control_file_info->minRecoveryPointTLI = ptr->minRecoveryPointTLI;
         control_file_info->minRecoveryPoint = ptr->minRecoveryPoint;
+#else
+	fprintf(stderr, "ERROR: please use a repmgr version built for PostgreSQL 12\n");
+	exit(ERR_BAD_CONFIG);
+#endif
     }
     else if (version_num >= 110000)
 	{


### PR DESCRIPTION
Totally, there are two building errors as below described.

**The first error:**
repmgr_version.h:5:38: 错误：missing binary operator beforee token "120000"
#define  PG_ACTUAL_VERSION_NUM 100011 120000

**The second error:**
controldata.c:315:9: 错误：未知的类型名‘ControlFileData12’
         ControlFileData12 *ptr = (struct ControlFileData12 *)ControlFileDataPtr;
         ^
controldata.c:315:34: 警告：从不兼容的指针类型初始化 [默认启用]
         ControlFileData12 *ptr = (struct ControlFileData12 *)ControlFileDataPtr;
                                  ^
controldata.c:316:51: 错误：在非结构或联合中请求成员‘system_identifier’
         control_file_info->system_identifier = ptr->system_identifier;
                                                   ^
controldata.c:317:39: 错误：在非结构或联合中请求成员‘state’
         control_file_info->state = ptr->state;
                                       ^
controldata.c:318:44: 错误：在非结构或联合中请求成员‘checkPoint’
         control_file_info->checkPoint = ptr->checkPoint;
                                            ^
controldata.c:319:55: 错误：在非结构或联合中请求成员‘data_checksum_version’
         control_file_info->data_checksum_version = ptr->data_checksum_version;
                                                       ^
controldata.c:320:42: 错误：在非结构或联合中请求成员‘checkPointCopy’
         control_file_info->timeline = ptr->checkPointCopy.ThisTimeLineID;
                                          ^
controldata.c:321:53: 错误：在非结构或联合中请求成员‘minRecoveryPointTLI’
         control_file_info->minRecoveryPointTLI = ptr->minRecoveryPointTLI;
                                                     ^
controldata.c:322:50: 错误：在非结构或联合中请求成员‘minRecoveryPoint’
         control_file_info->minRecoveryPoint = ptr->minRecoveryPoint;